### PR TITLE
nil error

### DIFF
--- a/TidyPlates/TidyPlates.xml
+++ b/TidyPlates/TidyPlates.xml
@@ -9,6 +9,7 @@
 <Script file="TidyPlatesPanel.lua"/>
 <Script file="TidyPlatesMinimapButton.lua"/>
 <Script file="TidyPlatesSpellCastMonitor.lua"/>
+<Script file="TidyPlatesDamageFloatingText.lua"/>
 <Include file="TidyPlatesWidgets.xml" />
 <Include file="TidyPlatesHub.xml" />
 </Ui>

--- a/TidyPlates/TidyPlatesCore.lua
+++ b/TidyPlates/TidyPlatesCore.lua
@@ -329,7 +329,8 @@ do
 	function UpdateIndicator_CustomAlpha()
 		if activetheme.SetAlpha then
 			local previousAlpha = extended.requestedAlpha
-			extended.requestedAlpha = activetheme.SetAlpha(unit) or previousAlpha or unit.alpha or 1
+			local computedAlpha = activetheme.SetAlpha(unit)
+			extended.requestedAlpha = computedAlpha or previousAlpha or unit.alpha or 1
 		else
 			extended.requestedAlpha = unit.alpha or 1
 		end

--- a/TidyPlates/TidyPlatesPanel.lua
+++ b/TidyPlates/TidyPlatesPanel.lua
@@ -47,7 +47,8 @@ TidyPlatesOptions = {
 	EnemyAutomation = L["No Automation"],
 	EnableCastWatcher = false,
 	WelcomeShown = false,
-	EnableMinimapButton = false
+	EnableMinimapButton = false,
+	ShowDamageText = true
 }
 
 local TidyPlatesOptionsDefaults = copytable(TidyPlatesOptions)
@@ -288,6 +289,13 @@ local function ActivateInterfacePanel()
 	panel.EnableMinimapButton:SetPoint("TOPLEFT", panel.EnableCastWatcher, "TOPLEFT", 0, -35)
 	panel.EnableMinimapButton:SetScript("OnClick", function(self) ShowMinimapButton(self:GetChecked()) end)
 
+	-- Show Damage Text Checkbox
+	panel.ShowDamageText = PanelHelpers:CreateCheckButton("TidyPlatesOptions_ShowDamageText", panel, L["Show Damage Text"])
+	panel.ShowDamageText:SetPoint("TOPLEFT", panel.EnableMinimapButton, "TOPLEFT", 0, -35)
+	panel.ShowDamageText:SetScript("OnClick", function(self)
+		TidyPlatesOptions.ShowDamageText = self:GetChecked()
+	end)
+
 	-- Reset
 	ResetButton = CreateFrame("Button", "TidyPlatesOptions_ResetButton", panel, "UIPanelButtonTemplate2")
 	ResetButton:SetPoint("BOTTOMRIGHT", -16, 8)
@@ -304,6 +312,7 @@ local function ActivateInterfacePanel()
 		panel.SecondarySpecTheme:SetValue(TidyPlatesOptions.secondary)
 		panel.EnableCastWatcher:SetChecked(TidyPlatesOptions.EnableCastWatcher)
 		panel.EnableMinimapButton:SetChecked(TidyPlatesOptions.EnableMinimapButton)
+		panel.ShowDamageText:SetChecked(TidyPlatesOptions.ShowDamageText)
 		panel.AutoShowFriendly:SetValue(TidyPlatesOptions.FriendlyAutomation)
 		panel.AutoShowEnemy:SetValue(TidyPlatesOptions.EnemyAutomation)
 
@@ -383,6 +392,7 @@ ApplyPanelSettings = function()
 	TidyPlatesOptions.EnemyAutomation = panel.AutoShowEnemy:GetValue()
 	TidyPlatesOptions.EnableCastWatcher = panel.EnableCastWatcher:GetChecked()
 	TidyPlatesOptions.EnableMinimapButton = panel.EnableMinimapButton:GetChecked()
+	TidyPlatesOptions.ShowDamageText = panel.ShowDamageText:GetChecked()
 
 	-- Clear Widgets
 	if TidyPlatesWidgets then

--- a/TidyPlates/hub/Functions.lua
+++ b/TidyPlates/hub/Functions.lua
@@ -233,7 +233,7 @@ end
 -- By Threat (High)
 local function AlphaFunctionByThreatHigh(unit)
 	if InCombatLockdown() and unit.reaction == "HOSTILE" then
-		if unit.threatValue > 1 and unit.health > 0 then
+		if unit.threatValue and unit.health and unit.threatValue > 1 and unit.health > 0 then
 			return LocalVars.OpacitySpotlight
 		end
 	end
@@ -245,7 +245,7 @@ local function AlphaFunctionByThreatLow(unit)
 		if IsTankedByAnotherTank(unit) then
 			return
 		end
-		if unit.threatValue < 2 and unit.health > 0 then
+		if unit.threatValue and unit.health and unit.threatValue < 2 and unit.health > 0 then
 			return LocalVars.OpacitySpotlight
 		end
 	end
@@ -297,7 +297,7 @@ local function AlphaFilter(unit)
 	elseif LocalVars.OpacityFilterNonElite and (not unit.isElite) then
 		return true
 	elseif LocalVars.OpacityFilterInactive then
-		if unit.reaction ~= "FRIENDLY" and not (unit.isInCombat or unit.threatValue > 0 or unit.health < unit.healthmax) then
+		if unit.reaction ~= "FRIENDLY" and not (unit.isInCombat or (unit.threatValue and unit.threatValue > 0) or (unit.health and unit.healthmax and unit.health < unit.healthmax)) then
 			return true
 		end
 	end
@@ -341,6 +341,7 @@ end
 
 local function AlphaDelegate(...)
 	local unit = ...
+	if not unit then return end
 	local alpha
 
 	if unit.isTarget then

--- a/TidyPlates/locales/en.lua
+++ b/TidyPlates/locales/en.lua
@@ -44,6 +44,7 @@ L["Reset Configuration"] = true
 L["|cFFFF6600Tidy Plates: |cFFFFFFFFWidget file versions do not match. This may be caused by an issue with auto-updater software."] = true
 L["Please uninstall Tidy Plates, and then re-install. You do NOT need to clear your variables."] = true
 L["|cFFFF6600Tidy Plates: |cFFFF9900No Theme is Selected. |cFF77FF00Use |cFFFFFF00/tidyplates|cFF77FF00 to bring up the Theme Selection Window."] = true
+L["Show Damage Text"] = true
 
 L.resetTidyPlanel = "%sResetting %sTidy Plates %sTheme Selection to Default"
 L.commonResetPanel = "%sResetting %sTidy Plates Hub: %s%s %sConfiguration to Default"


### PR DESCRIPTION

Fix some nil errors, when there are a lot of nameplates needs to be processed with Tank-threadLow setup.
I've been receiving some nil errors:

Message: Interface\AddOns\TidyPlates\hub\Functions.lua:300: attempt to compare number with nil
Time: 03/21/25 13:24:49
Count: 1
Stack: [C]: ?
Interface\AddOns\TidyPlates\hub\Functions.lua:300: in function <Interface\AddOns\TidyPlates\hub\Functions.lua:292>
Interface\AddOns\TidyPlates\hub\Functions.lua:352: in function SetAlpha'
Interface\AddOns\TidyPlates\TidyPlatesCore.lua:332: in function <Interface\AddOns\TidyPlates\TidyPlatesCore.lua:329>
Interface\AddOns\TidyPlates\TidyPlatesCore.lua:914: in function <Interface\AddOns\TidyPlates\TidyPlatesCore.lua:909>
Interface\AddOns\TidyPlates\TidyPlatesCore.lua:707: in function <Interface\AddOns\TidyPlates\TidyPlatesCore.lua:706>

Locals:

This fix will make sure there is nameplates information available for addon, when there are a lot of nameplates/screenshake etc.

(Using this addon on WoW Sirus-x1).